### PR TITLE
Add an empty namescape

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
 declare function padLeft (str: string, num: number, ch?: string): string;
 
+namespace padLeft {}
+
 export = padLeft;


### PR DESCRIPTION
Due to https://github.com/Microsoft/TypeScript/issues/5073 it is not possible to import this package in node projects using
`import * as padleft from "pad-left";` without empty namespace.

Error before adding namespace was:
`Error:(7, 26) TS2497: Module ''pad-left'' resolves to a non-module entity and cannot be imported using this construct.`
